### PR TITLE
Queue module in Lua can be assigned to custom variable

### DIFF
--- a/asynctnt_queue/queue.py
+++ b/asynctnt_queue/queue.py
@@ -9,12 +9,13 @@ __all__ = (
 
 class Queue:
     __slots__ = (
-        '_conn', '_tube_cls', '_tubes'
+        '_conn', '_tube_cls', '_tubes', '_namespace'
     )
 
     def __init__(self,
                  conn: asynctnt.Connection,
-                 tube_cls=Tube):
+                 tube_cls=Tube,
+                 namespace='queue'):
         """
             Queue constructor.
 
@@ -25,12 +26,16 @@ class Queue:
             :param tube_cls:
                 Tube class that is used for Tube creation (default is
                 :class:`asynctnt_queue.Tube`)
+            :param namespace:
+                Variable which was used for queue module import (
+                deafult is `queue`)
         """
         assert isinstance(conn, asynctnt.Connection), \
             'conn must be asynctnt.Connection instance'
         self._conn = conn
         self._tube_cls = tube_cls
         self._tubes = {}
+        self._namespace = namespace
 
     @property
     def conn(self):
@@ -40,6 +45,15 @@ class Queue:
             :returns: :class:`asynctnt.Connection` instance
         """
         return self._conn
+
+    @property
+    def namespace(self):
+        """
+            Queues namespace
+
+            :returns: :class:`str` instance
+        """
+        return self._namespace
 
     def tube(self, name):
         """
@@ -69,7 +83,7 @@ class Queue:
         if tube_name is not None:
             args = (tube_name,)
 
-        res = await self._conn.call('queue.statistics', args)
+        res = await self._conn.call('{}.statistics'.format(self._namespace), args)
         if self._conn.version < (1, 7):
             return res.body[0][0]
         return res.body[0]

--- a/asynctnt_queue/tube.py
+++ b/asynctnt_queue/tube.py
@@ -20,8 +20,8 @@ _FUNCS = [
 ]
 
 
-def build_func_name(tube_name, func_name):
-    return 'queue.tube.{}:{}'.format(tube_name, func_name)
+def build_func_name(namespace, tube_name, func_name):
+    return '{}.tube.{}:{}'.format(namespace, tube_name, func_name)
 
 
 class Tube:
@@ -33,14 +33,14 @@ class Tube:
         self._queue = queue
         self._name = name
 
-        self.__funcs = {f: build_func_name(self._name, f) for f in _FUNCS}
+        self.__funcs = {f: build_func_name(self._queue.namespace, self._name, f) for f in _FUNCS}
 
     @property
     def queue(self):
         """
             Returns corresponding queue object
 
-            :returns: :class:`asynctnt_queue.Tube` instance
+            :returns: :class:`asynctnt_queue.Queue` instance
         """
         return self._queue
 
@@ -51,7 +51,7 @@ class Tube:
 
             :returns: :class:`asynctnt.Connection` instance
         """
-        return self._queue._conn
+        return self._queue.conn
 
     @property
     def name(self):


### PR DESCRIPTION
User can set custom path to queue module in Lua on Queue object initialization.